### PR TITLE
Gcs compose operator and copy to S3 operator

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,10 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+apache-airflow = "==1.10.3"
+
+[requires]
+python_version = "3.7"

--- a/huq/__init__.py
+++ b/huq/__init__.py
@@ -1,0 +1,24 @@
+from airflow.plugins_manager import AirflowPlugin
+
+from huq.bigquery import BigQueryChainOperator, BigQueryToCloudStorageChainOperator
+from huq.gcs import GoogleCloudStorageComposePrefixOperator, GoogleCloudStorageComposePrefixChainOperator
+
+
+# Defining the plugin class
+class AirflowChainsPlugin(AirflowPlugin):
+    name = "huq"
+    operators = [
+        BigQueryChainOperator,
+        BigQueryToCloudStorageChainOperator,
+        GoogleCloudStorageComposePrefixOperator,
+        GoogleCloudStorageComposePrefixChainOperator,
+    ]
+    sensors = []
+    hooks = []
+    executors = []
+    macros = []
+    admin_views = []
+    flask_blueprints = []
+    menu_links = []
+    appbuilder_views = []
+    appbuilder_menu_items = []

--- a/huq/__init__.py
+++ b/huq/__init__.py
@@ -1,17 +1,18 @@
 from airflow.plugins_manager import AirflowPlugin
 
 from huq.bigquery import BigQueryChainOperator, BigQueryToCloudStorageChainOperator
-from huq.gcs import GoogleCloudStorageComposePrefixOperator, GoogleCloudStorageComposePrefixChainOperator
+from huq.gcs import GoogleCloudStorageComposePrefixOperator, GoogleCloudStorageComposePrefixChainOperator, GoogleCloudStorageToS3CopyChainOperator
 
 
 # Defining the plugin class
-class AirflowChainsPlugin(AirflowPlugin):
+class AirflowHuqPlugin(AirflowPlugin):
     name = "huq"
     operators = [
         BigQueryChainOperator,
         BigQueryToCloudStorageChainOperator,
         GoogleCloudStorageComposePrefixOperator,
         GoogleCloudStorageComposePrefixChainOperator,
+        GoogleCloudStorageToS3CopyChainOperator,
     ]
     sensors = []
     hooks = []

--- a/huq/bigquery.py
+++ b/huq/bigquery.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.plugins_manager import AirflowPlugin
 from airflow.models import BaseOperator
 
 from airflow.contrib.hooks.bigquery_hook import BigQueryHook
@@ -344,18 +343,3 @@ class BigQueryToCloudStorageChainOperator(BaseOperator):
                     self.field_delimiter,
                     self.print_header,
                     self.labels)
-
-
-# Defining the plugin class
-class AirflowChainsPlugin(AirflowPlugin):
-    name = "chains"
-    operators = [BigQueryChainOperator, BigQueryToCloudStorageChainOperator]
-    sensors = []
-    hooks = []
-    executors = []
-    macros = []
-    admin_views = []
-    flask_blueprints = []
-    menu_links = []
-    appbuilder_views = []
-    appbuilder_menu_items = []

--- a/huq/gcs.py
+++ b/huq/gcs.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+import tempfile
+
+GCS_COMPOSE_CHUNKS = 30
+
+
+class GoogleCloudStorageComposePrefixOperator(BaseOperator):
+    """
+    Downloads a file from Google Cloud Storage.
+    :param bucket: The Google cloud storage bucket where the object is. (templated)
+    :type bucket: str
+    :param source_objects_prefix: List of GCS objects to compose. (templated)
+    :type source_objects_prefix: str
+    :param destination_uri: Destination GCS object path. (templated)
+    :type destination_uri: str
+    :param num_retries: Number of retries for each compose action.
+    :type num_retries: int
+    :param delete_sources: Flag to enable source deletion after composition.
+    :type num_retries: bool
+    :param google_cloud_storage_conn_id: The connection ID to use when
+        connecting to Google cloud storage.
+    :type google_cloud_storage_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+    template_fields = ('bucket', 'source_objects_prefix', 'destination_uri',)
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 bucket,
+                 source_objects_prefix,
+                 destination_uri,
+                 compose_num_retries=5,
+                 delete_sources=False,
+                 clear_destination=True,
+                 google_cloud_storage_conn_id='google_cloud_default',
+                 delegate_to=None,
+                 *args,
+                 **kwargs):
+        super(GoogleCloudStorageComposePrefixOperator, self).__init__(*args, **kwargs)
+        self.bucket = bucket
+        self.source_objects_prefix = source_objects_prefix
+        self.destination_uri = destination_uri
+        self.compose_num_retries = compose_num_retries
+        self.delete_sources = delete_sources
+        self.clear_destination = clear_destination
+        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.delegate_to = delegate_to
+
+    def execute(self, context):
+        self.log.info(
+            'Compose all object matching "%s" prefix into "%s"',
+            self.source_objects_prefix,
+            self.destination_uri
+        )
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            delegate_to=self.delegate_to
+        )
+        self._compose(
+            hook=hook,
+            delete_sources=self.delete_sources,
+            clear_destination=self.clear_destination
+        )
+        return
+
+    def _compose(self, hook, delete_sources=False, clear_destination=True):
+        bucket = self.bucket
+        source_objects_prefix = self.source_objects_prefix
+        destination_uri = self.destination_uri
+        self.log.info(
+            'Compose all object matching "%s" prefix into "%s"',
+            source_objects_prefix,
+            destination_uri
+        )
+
+        source_objects = hook.list(bucket=bucket, prefix=source_objects_prefix)
+        if source_objects is None or len(source_objects) == 0:
+            self.log.info('No objects found matching the prefix: "%s"', source_objects_prefix)
+
+        if clear_destination and hook.exists(bucket=bucket, object=destination_uri):
+            self.log.info('Delete %s', destination_uri)
+            hook.delete(bucket=bucket, object=destination_uri)
+
+        for i in range(0, len(source_objects), GCS_COMPOSE_CHUNKS):
+            end_idx = min(i + GCS_COMPOSE_CHUNKS, len(source_objects)) - 1
+            self.log.info('Compose objects form %d to %d', i, end_idx)
+            hook.compose(
+                bucket=bucket,
+                source_objects=source_objects[i:end_idx],
+                destination_object=destination_uri,
+                num_retries=self.compose_num_retries
+            )
+        if delete_sources:
+            for source_object in source_objects:
+                hook.delete(bucket=bucket, object=source_object)
+        return
+
+
+class GoogleCloudStorageComposePrefixChainOperator(BaseOperator):
+    """
+    Downloads a file from Google Cloud Storage.
+    :param bucket: The Google cloud storage bucket where the object is. (templated)
+    :type bucket: str
+    :param source_objects_prefix: List of GCS objects to compose. (templated)
+    :type source_objects_prefix: str
+    :param destination_object: Destination GCS object path. (templated)
+    :type destination_object: str
+    :param num_retries: Number of retries for each compose action.
+    :type num_retries: int
+    :param delete_sources: Flag to enable source deletion after composition.
+    :type num_retries: bool
+    :param google_cloud_storage_conn_id: The connection ID to use when
+        connecting to Google cloud storage.
+    :type google_cloud_storage_conn_id: str
+    :param delegate_to: The account to impersonate, if any.
+        For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+    template_fields = ('buckets', 'source_objects_prefixes', 'destination_uris',)
+    ui_color = '#f0eee4'
+
+    @apply_defaults
+    def __init__(self,
+                 buckets,
+                 source_objects_prefixes,
+                 destination_uris,
+                 compose_num_retries=5,
+                 delete_sources=False,
+                 clear_destination=True,
+                 google_cloud_storage_conn_id='google_cloud_default',
+                 delegate_to=None,
+                 *args,
+                 **kwargs):
+        super(GoogleCloudStorageComposePrefixChainOperator, self).__init__(*args, **kwargs)
+        self.buckets = buckets
+        self.source_objects_prefixes = source_objects_prefixes
+        self.destination_uris = destination_uris
+        self.compose_num_retries = compose_num_retries
+        self.delete_sources = delete_sources
+        self.clear_destination = clear_destination
+        self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
+        self.delegate_to = delegate_to
+
+        if self.buckets is None:
+            raise TypeError('{} missing 1 required positional '
+                            'argument: `buckets`'.format(self.task_id))
+        elif not isinstance(buckets, list):
+            raise TypeError('{} `buckets` parameter type needs to be str or list'.format(self.task_id))
+
+        if self.source_objects_prefixes is None:
+            raise TypeError('{} missing 1 required positional '
+                            'argument: `source_objects_prefixes`'.format(self.task_id))
+        elif not isinstance(source_objects_prefixes, list):
+            raise TypeError('{} `source_objects_prefixes` parameter type needs to be str or list'.format(self.task_id))
+
+        if self.destination_uris is None:
+            raise TypeError('{} missing 1 required positional '
+                            'argument: `destination_uris`'.format(self.task_id))
+        elif not isinstance(destination_uris, list):
+            raise TypeError('{} `destination_uris`parameter type '
+                            'needs to be str or list'.format(self.task_id))
+
+        if len(self.source_objects_prefixes) != len(self.destination_uris):
+            raise ValueError('{} `source_objects_prefixes` and `destination_cloud_storage_uris` '
+                             'need to have the same length'.format(self.task_id))
+
+    def execute(self, context):
+        hook = GoogleCloudStorageHook(
+            google_cloud_storage_conn_id=self.google_cloud_storage_conn_id,
+            delegate_to=self.delegate_to
+        )
+        self._compose(
+            hook=hook,
+            delete_sources=self.delete_sources,
+            clear_destination=self.clear_destination
+        )
+        return
+
+    def _compose(self, hook, delete_sources=False, clear_destination=True):
+        for i in range(0, len(self.source_objects_prefixes), 1):
+            bucket = self.buckets[i]
+            source_objects_prefix = self.source_objects_prefixes[i]
+            destination_uri = self.destination_uris[i]
+            self.log.info(
+                'Compose all object matching "%s" prefix into "%s"',
+                source_objects_prefix,
+                destination_uri
+            )
+
+            source_objects = hook.list(
+                bucket=bucket,
+                prefix=source_objects_prefix,
+                maxResults=1000,
+            )
+            if source_objects is None or len(source_objects) == 0:
+                self.log.warning('No objects found matching the prefix: "%s"', source_objects_prefix)
+                self.log.warning('Skip: "%s"', destination_uri)
+                continue
+
+            self.log.info('Number of object to compose: %d', len(source_objects))
+
+            if clear_destination and hook.exists(bucket=bucket, object=destination_uri):
+                self.log.info('Delete %s', destination_uri)
+                hook.delete(bucket=bucket, object=destination_uri)
+
+            for j in range(0, len(source_objects), GCS_COMPOSE_CHUNKS):
+                self.log.info('Compose objects from %d to %d', j, j+GCS_COMPOSE_CHUNKS-1)
+                objects_to_compose = source_objects[j:j + GCS_COMPOSE_CHUNKS]
+                # If we do more than one iteration we need to include destination_uri into source_objects
+                if j >= GCS_COMPOSE_CHUNKS:
+                    objects_to_compose.append(destination_uri)
+                hook.compose(
+                    bucket=bucket,
+                    source_objects=objects_to_compose,
+                    destination_object=destination_uri,
+                    num_retries=self.compose_num_retries
+                )
+            if delete_sources:
+                for source_object in source_objects:
+                    hook.delete(bucket=bucket, object=source_object)
+
+    def _consolidate(self, hook):
+        for i in range(0, len(self.destination_uris), 1):
+            tmp = tempfile.NamedTemporaryFile(suffix='.tmp',
+                                              prefix='gcs_consolidate_tmp_',
+                                              dir='/tmp')
+            hook.download(bucket=self.buckets[i], object=self.destination_uris[i], filename=tmp.name)
+            hook.upload(bucket=self.buckets[i], object=self.destination_uris[i], filename=tmp.name)
+        return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-apache-airflow==1.10.3


### PR DESCRIPTION
- Reorganised the operators for a better extensibility
- `GoogleCloudStorageComposePrefixOperator` composes a prefix into a single file.
- `GoogleCloudStorageComposePrefixChainOperator` same as above but serialising multiple composition to multiple destination. This reduce the number of tasks on airflow.
-`GoogleCloudStorageToS3CopyChainOperator` copy (overwrite) a single GCS object to a single S3 object.
